### PR TITLE
use the production URL for hamlet

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,7 @@ const config = {
   appRootUrl: localStorage.getItem('appRootUrl') || `${window.location.origin}${window.location.pathname}`,
   proxyUrl: localStorage.getItem('proxyUrl') || process.env.PROXY_HOST || 'https://subject-assistant-proxy.zooniverse.org',
   hamletUrl: (env === 'production')
-    ? 'https://hamlet-staging.zooniverse.org/'
+    ? 'https://hamlet.zooniverse.org/'
     : 'https://hamlet-staging.zooniverse.org/',
   panoptesAppId: (env === 'production')
     ? '9177dbfa64561b23b3089efedd75b0a52b8aa5a5c9de18cf966670cd3b0f4449'


### PR DESCRIPTION
This PR switches the hamlet service URL from staging to prod. 

For historical reasons hamlet was only deployed via staging service but it uses prod services to fetch data etc and `hamlet.zooniverse.org` and `hamlet-staging.zooniverse.org` both hit the same hamlet service. it's not ideal to have a staging URL linking prod services so we can use the prod URL here instead.