### PR TITLE
Build with Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:14-slim as builder
+FROM node:18-slim as builder
+
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
@@ -10,7 +13,7 @@ RUN chown -R node:node .
 
 USER node
 
-RUN npm install
+RUN npm ci
 
 COPY ./ .
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "webpack-dev-server": "^4.11.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "mobx": "^5.15.7",
         "mobx-react": "^6.3.1",
         "mobx-state-tree": "^3.17.3",
-        "node-fetch": "^2.6.7",
         "panoptes-client": "^4.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -9805,8 +9804,7 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "mobx": "^5.15.7",
     "mobx-react": "^6.3.1",
     "mobx-state-tree": "^3.17.3",
-    "node-fetch": "^2.6.7",
     "panoptes-client": "^4.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "dotenv": "^16.0.3",

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -1,5 +1,4 @@
 const express = require('express')
-const fetch = require('node-fetch')
 require('dotenv').config()
 
 const server = express()


### PR DESCRIPTION
- Bump the Dockerfile to Node 18. Only install production dependencies.
- Bump the package file to Node 18.
- Remove `node-fetch`.
- Closes #128. 