### PR TITLE
Revert "Bump mobx from 5.15.7 to 6.9.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "json2csv": "^5.0.6",
-        "mobx": "^6.9.0",
+        "mobx": "^5.15.7",
         "mobx-react": "^6.3.1",
         "mobx-state-tree": "^3.17.3",
         "panoptes-client": "^5.2.5",
@@ -4350,13 +4350,9 @@
       }
     },
     "node_modules/mobx": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.9.0.tgz",
-      "integrity": "sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
-      }
+      "version": "5.15.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
+      "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw=="
     },
     "node_modules/mobx-react": {
       "version": "6.3.1",
@@ -9518,9 +9514,9 @@
       }
     },
     "mobx": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.9.0.tgz",
-      "integrity": "sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ=="
+      "version": "5.15.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
+      "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw=="
     },
     "mobx-react": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "json2csv": "^5.0.6",
-    "mobx": "^6.9.0",
+    "mobx": "^5.15.7",
     "mobx-react": "^6.3.1",
     "mobx-state-tree": "^3.17.3",
     "panoptes-client": "^5.2.5",


### PR DESCRIPTION
Reverts zooniverse/subject-assistant#146

MobX 6 breaks the stores. It appears that creating a default store with e.g. `AuthStore.create({})` no longer works in the current context. Reverting to mobX 5.